### PR TITLE
Initial versions of user quickstart docs

### DIFF
--- a/user/getting-started.md
+++ b/user/getting-started.md
@@ -18,6 +18,7 @@ go get -u github.com/bblfsh/sdk/...
 
 # build a driver + container
 git clone https://github.com/bblfsh/java-driver.git
+go get -v -t ./...
 make build
 ```
 

--- a/user/getting-started.md
+++ b/user/getting-started.md
@@ -1,4 +1,35 @@
 
 # Getting Started
 
-* **TODO**
+Right now, 2017Q2 the easiest way to get started is to use local driver development environment: manually clone and build a container for a language driver with an SDK, then run it through Docker in order to get source -> UAST.
+
+I.e for a [Java driver](https://github.com/bblfsh/java-driver) :
+
+## Pre-requests
+ - Docker
+ - Go, for SKD build
+ - (macOS) `coreutils` and `gettext`, for SDK to work
+
+
+## Build
+```
+# build SDK
+go get -u github.com/bblfsh/sdk/...
+
+# build a driver + container
+git clone https://github.com/bblfsh/java-driver.git
+make build
+```
+
+In future, this will be replaced by `docker fetch` for the pre-build language driver containers
+
+## Run
+Get latest commit hash and run
+
+```
+cat 'native/src/main/java/bblfsh/Request.java' | docker run -it bblfsh/java-driver:dev-<commit[:6]> parse-native
+```
+
+to get UAST for the given `.java` file.
+
+For further details on using a driver please refer [Driver protocol](../driver/protocol.md#example)


### PR DESCRIPTION
For a user to quickly have a taste of what Babelfish is, it would be nice to have short tl;dr for getting from Source -> UAST

This is a temporary attempt to do so, for the current status of the project. It is expected to be updated, covering the same case, as project matures, docker images got published to dockerHub, etc.

The Run section right now does not work as described, but if people see value in it, I would be happy to submit a PR to [bblfsh/sdk/protocol/driver.go#L57](https://github.com/bblfsh/sdk/blob/master/protocol/driver.go#L57) adding something like this `parse-native-stdin`.

Please, let me know what you think! 