### PR TITLE
proposals: Add them to the summary so they're parsed

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -24,3 +24,10 @@
 * [Adding UAST Annotations](driver/annotations.md)
 * [Driver Protocol](driver/protocol.md)
 * [Internal Protocol](driver/internal-protocol.md)
+
+## BIP Index
+
+* [Babelfish Improvement Proposals](proposals/README.md)
+
+* [BIP0: Template](proposals/bip-000.md)
+* [BIP1: Purpose and Guidelines](proposals/bip-001.md)


### PR DESCRIPTION
Pages that are not added to the SUMMARY are not parsed, so links to BIPs are not currently working (i.e.: https://doc.bblf.sh/proposals/bip-000.md).

Fix commit should fix that.