### PR TITLE
Add links to language annotations

### DIFF
--- a/languages.md
+++ b/languages.md
@@ -3,8 +3,8 @@
 
 | Language    | Key        | Status | Version | GitHub    | Container | Annotations |
 |-------------|------------|--------|---------|-----------|-----------|-------------|
-| Python      | python     | beta   | v0.3.0  |[✓](https://github.com/bblfsh/python-driver) | [✓](https://hub.docker.com/r/bblfsh/python-driver/) | [✓](https://github.com/bblfsh/python-driver/ANNOTATION.md) |
-| Java        | java       | alpha  | v0.2.0  |[✓](https://github.com/bblfsh/java-driver) | [✓](https://hub.docker.com/r/bblfsh/java-driver/) | [✓](https://github.com/bblfsh/java-driver/ANNOTATION.md) |
+| Python      | python     | beta   | v0.3.0  |[✓](https://github.com/bblfsh/python-driver) | [✓](https://hub.docker.com/r/bblfsh/python-driver/) | [✓](https://github.com/bblfsh/python-driver/blob/master/ANNOTATION.md) |
+| Java        | java       | alpha  | v0.2.0  |[✓](https://github.com/bblfsh/java-driver) | [✓](https://hub.docker.com/r/bblfsh/java-driver/) | [✓](https://github.com/bblfsh/java-driver/blob/master/ANNOTATION.md) |
 | Bash        | bash       | early  | ✖       | [✓](https://github.com/bblfsh/bash-driver) | ✖ | ✖ |
 | Clojure     | clojure    | early  | ✖       | [✓](https://github.com/bblfsh/clojure-driver) | ✖ | ✖ |
 | Elixir      | elixir     | early  | ✖       | [✓](https://github.com/bblfsh/elixir-driver) | ✖ | ✖ |

--- a/languages.md
+++ b/languages.md
@@ -1,22 +1,22 @@
 
 # Supported Languages
 
-| Language    | Key        | Status | Version | GitHub    | Container |
-|-------------|------------|--------|---------|-----------|-----------|
-| Python      | python     | beta   | v0.3.0  |[✓](https://github.com/bblfsh/python-driver) | [✓](https://hub.docker.com/r/bblfsh/python-driver/) |
-| Java        | java       | alpha  | v0.2.0  |[✓](https://github.com/bblfsh/java-driver) | [✓](https://hub.docker.com/r/bblfsh/java-driver/) |
-| Bash        | bash       | early  | ✖       | [✓](https://github.com/bblfsh/bash-driver) | ✖ |
-| Clojure     | clojure    | early  | ✖       | [✓](https://github.com/bblfsh/clojure-driver) | ✖ |
-| Elixir      | elixir     | early  | ✖       | [✓](https://github.com/bblfsh/elixir-driver) | ✖ |
-| Erlang      | erlang     | early  | ✖       | [✓](https://github.com/bblfsh/erlang-driver) | ✖ |
-| Go          | go         | early  | ✖       | [✓](https://github.com/bblfsh/go-driver) | ✖ |
-| JavaScript  | javascript | early  | ✖       | [✓](https://github.com/bblfsh/javascript-driver) | ✖ |
-| Lua         | lua        | early  | ✖       | [✓](https://github.com/bblfsh/lua-driver) | ✖ |
-| PHP         | php        | early  | ✖       | [✓](https://github.com/bblfsh/php-driver) | ✖ |
-| R           | r          | early  | ✖       | [✓](https://github.com/bblfsh/r-driver) | ✖ |
-| Ruby        | ruby       | early  | ✖       | [✓](https://github.com/bblfsh/ruby-driver) | ✖ |
-| Rust        | rust       | early  | ✖       | [✓](https://github.com/bblfsh/rust-driver) | ✖ |
-| TypeScript  | typescript | early  | ✖       | [✓](https://github.com/bblfsh/typescript-driver) | ✖ |
-| OCaml       | ocaml      | planned  | ✖     | [✓](https://github.com/bblfsh/ocaml-driver) | ✖ |
+| Language    | Key        | Status | Version | GitHub    | Container | Annotations |
+|-------------|------------|--------|---------|-----------|-----------|-------------|
+| Python      | python     | beta   | v0.3.0  |[✓](https://github.com/bblfsh/python-driver) | [✓](https://hub.docker.com/r/bblfsh/python-driver/) | [✓](https://github.com/bblfsh/python-driver/ANNOTATION.md) |
+| Java        | java       | alpha  | v0.2.0  |[✓](https://github.com/bblfsh/java-driver) | [✓](https://hub.docker.com/r/bblfsh/java-driver/) | [✓](https://github.com/bblfsh/java-driver/ANNOTATION.md) |
+| Bash        | bash       | early  | ✖       | [✓](https://github.com/bblfsh/bash-driver) | ✖ | ✖ |
+| Clojure     | clojure    | early  | ✖       | [✓](https://github.com/bblfsh/clojure-driver) | ✖ | ✖ |
+| Elixir      | elixir     | early  | ✖       | [✓](https://github.com/bblfsh/elixir-driver) | ✖ | ✖ |
+| Erlang      | erlang     | early  | ✖       | [✓](https://github.com/bblfsh/erlang-driver) | ✖ | ✖ |
+| Go          | go         | early  | ✖       | [✓](https://github.com/bblfsh/go-driver) | ✖ | ✖ |
+| JavaScript  | javascript | early  | ✖       | [✓](https://github.com/bblfsh/javascript-driver) | ✖ | ✖ |
+| Lua         | lua        | early  | ✖       | [✓](https://github.com/bblfsh/lua-driver) | ✖ | ✖ |
+| PHP         | php        | early  | ✖       | [✓](https://github.com/bblfsh/php-driver) | ✖ | ✖ |
+| R           | r          | early  | ✖       | [✓](https://github.com/bblfsh/r-driver) | ✖ | ✖ |
+| Ruby        | ruby       | early  | ✖       | [✓](https://github.com/bblfsh/ruby-driver) | ✖ | ✖ |
+| Rust        | rust       | early  | ✖       | [✓](https://github.com/bblfsh/rust-driver) | ✖ | ✖ |
+| TypeScript  | typescript | early  | ✖       | [✓](https://github.com/bblfsh/typescript-driver) | ✖ | ✖ |
+| OCaml       | ocaml      | planned  | ✖     | [✓](https://github.com/bblfsh/ocaml-driver) | ✖ | ✖ |
 
 **Don't see your favorite language? [Help us!](community.md)**


### PR DESCRIPTION
Not sure if this is the expected way to link them. Let me know if you have a better idea.
I left bash driver out for now since trying to generate its annotations causes an error (it seems it has not been updated to reflect latest protocol changes yet).

Depends on #50, https://github.com/bblfsh/java-driver/pull/20 and https://github.com/bblfsh/python-driver/pull/24
Should close https://github.com/src-d/backlog/issues/701