### PR TITLE
Update clients and versions

### DIFF
--- a/languages.md
+++ b/languages.md
@@ -3,8 +3,8 @@
 
 | Language    | Key        | Status | Version | GitHub    | Container | Annotations |
 |-------------|------------|--------|---------|-----------|-----------|-------------|
-| Python      | python     | beta   | v0.9.0  |[✓](https://github.com/bblfsh/python-driver) | [✓](https://hub.docker.com/r/bblfsh/python-driver/) | [✓](https://github.com/bblfsh/python-driver/blob/master/ANNOTATION.md) |
-| Java        | java       | beta   | v0.6.0  |[✓](https://github.com/bblfsh/java-driver) | [✓](https://hub.docker.com/r/bblfsh/java-driver/) | [✓](https://github.com/bblfsh/java-driver/blob/master/ANNOTATION.md) |
+| Python      | python     | beta   | v1.0.0  |[✓](https://github.com/bblfsh/python-driver) | [✓](https://hub.docker.com/r/bblfsh/python-driver/) | [✓](https://github.com/bblfsh/python-driver/blob/master/ANNOTATION.md) |
+| Java        | java       | beta   | v1.0.0  |[✓](https://github.com/bblfsh/java-driver) | [✓](https://hub.docker.com/r/bblfsh/java-driver/) | [✓](https://github.com/bblfsh/java-driver/blob/master/ANNOTATION.md) |
 | Bash        | bash       | early  | ✖       | [✓](https://github.com/bblfsh/bash-driver) | ✖ | ✖ |
 | Clojure     | clojure    | early  | ✖       | [✓](https://github.com/bblfsh/clojure-driver) | ✖ | ✖ |
 | Elixir      | elixir     | early  | ✖       | [✓](https://github.com/bblfsh/elixir-driver) | ✖ | ✖ |

--- a/languages.md
+++ b/languages.md
@@ -1,22 +1,22 @@
 
 # Supported Languages
 
-| Language    | Key        | Status | Version | GitHub    | Container | Annotations |
-|-------------|------------|--------|---------|-----------|-----------|-------------|
-| Python      | python     | beta   | v1.0.0  |[✓](https://github.com/bblfsh/python-driver) | [✓](https://hub.docker.com/r/bblfsh/python-driver/) | [✓](https://github.com/bblfsh/python-driver/blob/master/ANNOTATION.md) |
-| Java        | java       | beta   | v1.0.0  |[✓](https://github.com/bblfsh/java-driver) | [✓](https://hub.docker.com/r/bblfsh/java-driver/) | [✓](https://github.com/bblfsh/java-driver/blob/master/ANNOTATION.md) |
-| Bash        | bash       | early  | ✖       | [✓](https://github.com/bblfsh/bash-driver) | ✖ | ✖ |
-| Clojure     | clojure    | early  | ✖       | [✓](https://github.com/bblfsh/clojure-driver) | ✖ | ✖ |
-| Elixir      | elixir     | early  | ✖       | [✓](https://github.com/bblfsh/elixir-driver) | ✖ | ✖ |
-| Erlang      | erlang     | early  | ✖       | [✓](https://github.com/bblfsh/erlang-driver) | ✖ | ✖ |
-| Go          | go         | early  | ✖       | [✓](https://github.com/bblfsh/go-driver) | ✖ | ✖ |
-| JavaScript  | javascript | early  | ✖       | [✓](https://github.com/bblfsh/javascript-driver) | ✖ | ✖ |
-| Lua         | lua        | early  | ✖       | [✓](https://github.com/bblfsh/lua-driver) | ✖ | ✖ |
-| PHP         | php        | early  | ✖       | [✓](https://github.com/bblfsh/php-driver) | ✖ | ✖ |
-| R           | r          | early  | ✖       | [✓](https://github.com/bblfsh/r-driver) | ✖ | ✖ |
-| Ruby        | ruby       | early  | ✖       | [✓](https://github.com/bblfsh/ruby-driver) | ✖ | ✖ |
-| Rust        | rust       | early  | ✖       | [✓](https://github.com/bblfsh/rust-driver) | ✖ | ✖ |
-| TypeScript  | typescript | early  | ✖       | [✓](https://github.com/bblfsh/typescript-driver) | ✖ | ✖ |
-| OCaml       | ocaml      | planned  | ✖     | [✓](https://github.com/bblfsh/ocaml-driver) | ✖ | ✖ |
+| Language   | Key        | Status  | GitHub                                           | Container                                           | Annotations                                                            |
+| ---------- | ---------- | ------- | ------------------------------------------------ | --------------------------------------------------- | ---------------------------------------------------------------------- |
+| Python     | python     | beta    | [✓](https://github.com/bblfsh/python-driver)     | [✓](https://hub.docker.com/r/bblfsh/python-driver/) | [✓](https://github.com/bblfsh/python-driver/blob/master/ANNOTATION.md) |
+| Java       | java       | beta    | [✓](https://github.com/bblfsh/java-driver)       | [✓](https://hub.docker.com/r/bblfsh/java-driver/)   | [✓](https://github.com/bblfsh/java-driver/blob/master/ANNOTATION.md)   |
+| Bash       | bash       | early   | [✓](https://github.com/bblfsh/bash-driver)       | ✖                                                   | ✖                                                                      |
+| Clojure    | clojure    | early   | [✓](https://github.com/bblfsh/clojure-driver)    | ✖                                                   | ✖                                                                      |
+| Elixir     | elixir     | early   | [✓](https://github.com/bblfsh/elixir-driver)     | ✖                                                   | ✖                                                                      |
+| Erlang     | erlang     | early   | [✓](https://github.com/bblfsh/erlang-driver)     | ✖                                                   | ✖                                                                      |
+| Go         | go         | early   | [✓](https://github.com/bblfsh/go-driver)         | ✖                                                   | ✖                                                                      |
+| JavaScript | javascript | early   | [✓](https://github.com/bblfsh/javascript-driver) | ✖                                                   | ✖                                                                      |
+| Lua        | lua        | early   | [✓](https://github.com/bblfsh/lua-driver)        | ✖                                                   | ✖                                                                      |
+| PHP        | php        | early   | [✓](https://github.com/bblfsh/php-driver)        | ✖                                                   | ✖                                                                      |
+| R          | r          | early   | [✓](https://github.com/bblfsh/r-driver)          | ✖                                                   | ✖                                                                      |
+| Ruby       | ruby       | early   | [✓](https://github.com/bblfsh/ruby-driver)       | ✖                                                   | ✖                                                                      |
+| Rust       | rust       | early   | [✓](https://github.com/bblfsh/rust-driver)       | ✖                                                   | ✖                                                                      |
+| TypeScript | typescript | early   | [✓](https://github.com/bblfsh/typescript-driver) | ✖                                                   | ✖                                                                      |
+| OCaml      | ocaml      | planned | [✓](https://github.com/bblfsh/ocaml-driver)      | ✖                                                   | ✖                                                                      |
 
 **Don't see your favorite language? [Help us!](community.md)**

--- a/user/language-clients.md
+++ b/user/language-clients.md
@@ -11,11 +11,12 @@ API](https://github.com/bblfsh/libuast/tree/master/src).
 Currently there are working or planned clients in different stages of development
 for these languages:
 
-|Language   | Status  | URL                                     | 
-|---------- |-------- |---------------------------------------- |
-| Python    | Alpha   | https://github.com/bblfsh/client-python | 
-| Go        | Alpha   | https://github.com/bblfsh/client-go     |
-| Java      | Planned | https://github.com/bblfsh/client-java   | 
+| Language | Status  | Libuast | URL                                    |
+| -------- | ------- | ------- | -------------------------------------- |
+| Python   | Beta    | ✓       | https://github.com/bblfsh/client-scala |
+| Go       | Alpha   | ✓       | https://github.com/bblfsh/client-scala |
+| Scala    | Alpha   | ✖        | https://github.com/bblfsh/client-scala |
+| Java     | Planned | ✖        | https://github.com/bblfsh/client-java  |
 
 ## Example
 

--- a/user/language-clients.md
+++ b/user/language-clients.md
@@ -11,12 +11,11 @@ API](https://github.com/bblfsh/libuast/tree/master/src).
 Currently there are working or planned clients in different stages of development
 for these languages:
 
-| Language | Status  | Libuast | URL                                    |
-| -------- | ------- | ------- | -------------------------------------- |
-| Python   | Beta    | ✓       | https://github.com/bblfsh/client-scala |
-| Go       | Alpha   | ✓       | https://github.com/bblfsh/client-scala |
-| Scala    | Alpha   | ✖        | https://github.com/bblfsh/client-scala |
-| Java     | Planned | ✖        | https://github.com/bblfsh/client-java  |
+| Language | Status | Libuast | URL                                     |
+| -------- | ------ | ------- | --------------------------------------- |
+| Python   | Beta   | ✓       | https://github.com/bblfsh/client-python |
+| Go       | Alpha  | ✓       | https://github.com/bblfsh/client-go     |
+| Scala    | Alpha  | ✖       | https://github.com/bblfsh/client-scala  |
 
 ## Example
 


### PR DESCRIPTION
- Updated driver versions, mark Python and Go clients as "beta".
- Added client-scala.
- Added a column for libuast integration in the clients table.