### PR TITLE
Fix Typo

### DIFF
--- a/user/language-clients.md
+++ b/user/language-clients.md
@@ -34,7 +34,7 @@ import (
 )
 
 func main() {
-	client, err := bblfsh.NewBblfshClient("localhost:9432")
+	client, err := bblfsh.NewClient("localhost:9432")
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
In https://doc.bblf.sh/user/language-clients.html it is wrote:
```go
package main

import (
    "gopkg.in/bblfsh/client-go.v1"
)

func main() {
    client, err := bblfsh.NewBblfshClient("localhost:9432")
...
```
which is not consistent with https://github.com/bblfsh/client-go/commit/90974edd86fa7ea5303846bcdfbb910bb8e347e3