### PR TITLE
Fix internal type name for  elements in XPath query example

### DIFF
--- a/user/uast-querying.md
+++ b/user/uast-querying.md
@@ -44,7 +44,7 @@ Internally, these are mapped in the XML node in the following way:
 
 This means that both language specific queries (InternalType, Properties) and language agnostic queries (Roles) can be done. For example:
 
-- All the numeric literals in Python: `//NumLiteral`
+- All the numeric literals in Python: `//Num`
 - All the numeric literals in ANY language: `//*[@roleNumber and @roleLiteral]`
 - All the integer literals in Python: `//*[@NumType='int']`
 


### PR DESCRIPTION
The example makes use of `NumLiteral` but there is no internal type with this name in the [python driver](https://github.com/bblfsh/python-driver). Instead, there is the `Num` internal type as you can see [here](https://github.com/bblfsh/python-driver/blob/master/driver/normalizer/pyast/pyast.go#L124).

Using the old example, [engine](https://github.com/src-d/engine) doesn't return anything.
```scala
scala> engine.getRepositories.getHEAD.getCommits.getFirstReferenceCommit.getBlobs
   .classifyLanguages.where('lang === "Python").extractUASTs
   .queryUAST("//NumLiteral", "uast", "result").extractTokens("result", "tokens")
   .select('path, 'lang, 'uast, 'tokens)
   .show(5, false)

+----------------------------+------+-------------+------+
|path                        |lang  |uast         |tokens|
+----------------------------+------+-------------+------+
|backup_automater_services.py|Python|[[B@c05aae9] |[]    |
|batch_file_rename.py        |Python|[[B@7ddbaac6]|[]    |
|check_file.py               |Python|[[B@5deed459]|[]    |
|check_for_sqlite_files.py   |Python|[[B@461b8155]|[]    |
|create_dir_if_not_there.py  |Python|[[B@6768399d]|[]    |
+----------------------------+------+-------------+------+
only showing top 5 rows
```

But with `Num` it works:
```scala
scala> engine.getRepositories.getHEAD.getCommits.getFirstReferenceCommit.getBlobs
  .classifyLanguages.where('lang === "Python")
  .extractUASTs.queryUAST("//Num", "uast", "result")
  .extractTokens("result", "tokens").select('path, 'lang, 'uast, 'tokens)
  .show(5, false)

+----------------------------+------+-------------+------------------+
|path                        |lang  |uast         |tokens            |
+----------------------------+------+-------------+------------------+
|backup_automater_services.py|Python|[[B@3aa9a1e3]|[]                |
|batch_file_rename.py        |Python|[[B@22c5269d]|[1, 2, 3, 1]      |
|check_file.py               |Python|[[B@439026ea]|[1, 0, 0, 0, 0, 2]|
|check_for_sqlite_files.py   |Python|[[B@28920016]|[100, 0, 16, 100] |
|create_dir_if_not_there.py  |Python|[[B@5f430a5e]|[]                |
+----------------------------+------+-------------+------------------+
only showing top 5 rows

```