### PR TITLE
Fix typo in README and adjust line breaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,7 @@
 
 ## Introduction
 
-**Babelfish is a self-hosted server for source code parsing.** The Babelfish service can parse any file, in any supported language, extracting an [Abstract Syntax Tree \(AST\)](https://en.wikipedia.org/wiki/Abstract_syntax_tree) from it  
-and converting it into a [**Universal Abstract Syntax Tree \(UAST\)**](uast/uast-specification.md) which enables further analysis and transformation with either the included tools or your own tools by using an standard format.
+**Babelfish is a self-hosted server for source code parsing.** The Babelfish service can parse any file, in any supported language, extracting an [Abstract Syntax Tree \(AST\)](https://en.wikipedia.org/wiki/Abstract_syntax_tree) from it and converting it into a [**Universal Abstract Syntax Tree \(UAST\)**](uast/uast-specification.md) which enables further analysis and transformation with either the included tools or your own tools by using an standard format.
 
 ### Motivation and Scope
 
@@ -17,28 +16,18 @@ This scope might expand in the future to full project analysis, where source cod
 
 Some of the use cases that we want to support with AST are:
 
-* **AST-based diff'ing.** Understanding changes made to code with finer-grained
+* **AST-based diff'ing.** Understanding changes made to code with finer-grained granularity. Is this commit changing variable names? Is it adding a loop?
 
-  granularity. Is this commit changing variable names? Is it adding a loop?
+* **Import extraction.** Extracting all imports from every language in a uniform way.
 
-* **Import extraction.** Extracting all imports from every language in a uniform
+* **Extract representation for Data Science experiments.** For example, extracting a list of all tokens for every file, or a list of all function calls, etc.
 
-  way.
-
-* **Extract representation for Data Science experiments.** For example, extracting
-
-  a list of all tokens for every file, or a list of all function calls, etc.
-
-* **Making statistics of language features.** How many people use
-
-  for-comprehension in Python?
+* **Making statistics of language features.** How many people use for-comprehension in Python?
 
 * **Detecting similar coding patterns across languages.**
-* **Programmer-asisting tools** Improved linters, safety analysis, idiomatic
 
-  usage, etc.
+* **Programmer-assisting tools** Improved linters, safety analysis, idiomatic usage, etc.
 
-### Further reading
+### Further Reading
 
 This repo contains the project documentation, which you can also see properly rendered at [https://doc.bblf.sh/](https://doc.bblf.sh/).
-


### PR DESCRIPTION
Fixes a typo: `s/Programmer-asisting/Programmer-assisting`

This commit also adjusts some line breaks, which in my humble opinion will make the README look better. Line breaks changed in https://github.com/bblfsh/documentation/commit/4e913927461e8d5e0b60c9016443813194b5c4b5, not sure whether it was intentional or not.

Commit message includes sign-off.