### PR TITLE
Include reminder to use docker exec when running bblfshd under docker

### DIFF
--- a/uast/uast-specification.md
+++ b/uast/uast-specification.md
@@ -18,7 +18,7 @@ type Node struct {
 
 **Check out the godoc for the SDK** [**UAST package**](https://godoc.org/gopkg.in/bblfsh/sdk.v2/uast) for the full documentation of the UAST structure and annotations in Go.
 
-**For other languages, check the** [**UAST protobuf definition**](https://github.com/bblfsh/sdk/blob/master/uast/generated.proto)**.**
+**For other languages, check the** [**UAST protobuf definition**](https://github.com/bblfsh/sdk/blob/94e3b212553e761677da180f321d9a7a60ebec5f/uast/generated.proto)**.**
 
 ## Syntax Tree Structure
 

--- a/using-babelfish/babelfish-protocol.md
+++ b/using-babelfish/babelfish-protocol.md
@@ -1,6 +1,6 @@
 # Babelfish Protocol
 
-The Babelfish client-server protocol uses [gRPC](http://www.grpc.io) for method selection \(with the [Protocol Buffers](https://developers.google.com/protocol-buffers/) format used for message serialization\). You can read [the server](https://github.com/bblfsh/sdk/blob/master/protocol/generated.proto) and [SDK](https://github.com/bblfsh/sdk/blob/master/uast/generated.proto) `.proto` files to see the format description of the messages and types involved, but we'll provide here a simple definition in JSON-like format. On the [next page](grpc-usage-example.md) we'll see a demo of how this comes together in practice with some code.
+The Babelfish client-server protocol uses [gRPC](http://www.grpc.io) for method selection \(with the [Protocol Buffers](https://developers.google.com/protocol-buffers/) format used for message serialization\). You can read [the server](https://github.com/bblfsh/sdk/blob/94e3b212553e761677da180f321d9a7a60ebec5f/protocol/generated.proto#L11) and [SDK](https://github.com/bblfsh/sdk/blob/94e3b212553e761677da180f321d9a7a60ebec5f/uast/generated.proto) `.proto` files to see the format description of the messages and types involved, but we'll provide here a simple definition in JSON-like format. On the [next page](grpc-usage-example.md) we'll see a demo of how this comes together in practice with some code.
 
 ## ParseRequest
 
@@ -30,7 +30,7 @@ This is the reply produced by the server as response to the above ParseRequest. 
 }
 ```
 
-The `uast` field would contain the UAST root node as an [`gopkg.in/bblfsh/sdk.v2/uast` type](https://github.com/bblfsh/sdk/blob/master/uast/generated.proto#L11) which as you can see in the linked definition includes the internal type \(the type used by the native AST\), a map with the properties, the UAST roles, the position of the source construct that generated the node and a list of children as we'll see in the next section.
+The `uast` field would contain the UAST root node as an [`gopkg.in/bblfsh/sdk.v2/uast` type](https://github.com/bblfsh/sdk/blob/94e3b212553e761677da180f321d9a7a60ebec5f/uast/generated.proto#L11) which as you can see in the linked definition includes the internal type \(the type used by the native AST\), a map with the properties, the UAST roles, the position of the source construct that generated the node and a list of children as we'll see in the next section.
 
 The status contains the return code of the Request. If it's != 0 (which will be
 mapped to "Ok" or "ok" in an enum in the clients) no further processing should

--- a/using-babelfish/getting-started.md
+++ b/using-babelfish/getting-started.md
@@ -128,7 +128,7 @@ Available commands:
 
 ### Driver management
 
-The _bblfshd's_ drivers can be installed, updated and removed with the `driver` command and its subcommands.
+The _bblfshd's_ drivers can be installed, updated and removed with the `driver` command and its subcommands. Remember to prefix all these commands with `docker exec -it bblfshd` if you are running bblfshd from a Docker image.
 
 Installing all official drivers:
 

--- a/using-babelfish/grpc-usage-example.md
+++ b/using-babelfish/grpc-usage-example.md
@@ -6,7 +6,7 @@ This example is done in Go but you could use the gRPC interface using [any progr
 
 ## Getting and compiling the `.proto` file
 
-The first step involving gRPC communication is getting the `.proto` file that defines the types involved in the communication. The [`.proto` format](https://developers.google.com/protocol-buffers/docs/proto) defines the structures and methods used for protocol buffer data. In the case of the Babelfish server protocol, you need to get [this `.proto` file](https://github.com/bblfsh/sdk/blob/master/protocol/generated.proto) from the SDK. Then you have to compile it to a source file with the required structures and methods. How you generate this module is language-dependent but usually it involves installing gRPC using your language package management tool \(if it has a package for it\) and then use one of the provided tools.
+The first step involving gRPC communication is getting the `.proto` file that defines the types involved in the communication. The [`.proto` format](https://developers.google.com/protocol-buffers/docs/proto) defines the structures and methods used for protocol buffer data. In the case of the Babelfish server protocol, you need to get [this `.proto` file](https://github.com/bblfsh/sdk/blob/94e3b212553e761677da180f321d9a7a60ebec5f/protocol/generated.proto) from the SDK. Then you have to compile it to a source file with the required structures and methods. How you generate this module is language-dependent but usually it involves installing gRPC using your language package management tool \(if it has a package for it\) and then use one of the provided tools.
 
 For this example, we'll use the [GogoProtobuf implementation](https://github.com/gogo/protobuf) for the Go language. This provides the `protoc-gen-gogo` `.proto` compiler so we'll use it to generate the `.go` interface module:
 
@@ -14,7 +14,7 @@ For this example, we'll use the [GogoProtobuf implementation](https://github.com
 $ protoc-gen-gogo --go_out=. generated.proto
 ```
 
-This will create a generated.pb.go file that we could then directly import into out Go code. Since the SDK is also written in Go, you could skip this step and import the modules with the [already generated serializers](https://github.com/bblfsh/sdk/blob/master/protocol/generated.pb.go) in the Babelfish's SDK.
+This will create a generated.pb.go file that we could then directly import into out Go code. Since the SDK is also written in Go, you could skip this step and import the modules with the [already generated serializers](https://github.com/bblfsh/sdk/blob/94e3b212553e761677da180f321d9a7a60ebec5f/uast/generated.proto#L11) in the Babelfish's SDK.
 
 ## Making requests
 


### PR DESCRIPTION
Fixes bblfsh/bblfshd/issues/180 (from the friction log).

Also updated the (now broken) links to the `.proto` files to point to the v1 branch until we write the docs for the new protocol.

cc @tsolakoua 

Signed-off-by: Juanjo Alvarez <juanjo@sourced.tech>