### PR TITLE
Doc: re-generate drivers list

### DIFF
--- a/languages.json
+++ b/languages.json
@@ -33,7 +33,7 @@
 		"Name": "C++",
 		"Language": "cpp",
 		"Status": "beta",
-		"SDKVersion": "2.13.0",
+		"SDKVersion": "2.14.2",
 		"Runtime": {
 			"OS": "alpine",
 			"NativeVersion": [
@@ -60,7 +60,7 @@
 		"Name": "C#",
 		"Language": "csharp",
 		"Status": "beta",
-		"SDKVersion": "2.13.3",
+		"SDKVersion": "2.14.1",
 		"Documentation": {},
 		"Runtime": {
 			"GoVersion": "1.10"
@@ -111,7 +111,7 @@
 		"Name": "Java",
 		"Language": "java",
 		"Status": "beta",
-		"SDKVersion": "2.13.0",
+		"SDKVersion": "2.14.2",
 		"Runtime": {
 			"OS": "alpine",
 			"NativeVersion": [
@@ -138,7 +138,7 @@
 		"Name": "JavaScript",
 		"Language": "javascript",
 		"Status": "beta",
-		"SDKVersion": "2.13.2",
+		"SDKVersion": "2.14.2",
 		"Documentation": {
 			"Description": "JavaScript driver for [babelfish](https://github.com/bblfsh/bblfshd).\n"
 		},
@@ -198,7 +198,7 @@
 		"Name": "Python",
 		"Language": "python",
 		"Status": "beta",
-		"SDKVersion": "2.13.4",
+		"SDKVersion": "2.14.0",
 		"Runtime": {
 			"OS": "alpine",
 			"NativeVersion": [
@@ -225,7 +225,7 @@
 		"Name": "Ruby",
 		"Language": "ruby",
 		"Status": "beta",
-		"SDKVersion": "2.13.4",
+		"SDKVersion": "2.14.1",
 		"Documentation": {
 			"Description": "ruby driver for [babelfish](https://github.com/bblfsh/bblfshd).\n"
 		},

--- a/languages.md
+++ b/languages.md
@@ -6,14 +6,14 @@
 | Language   | Key        | Status  | SDK  | AST\* | UAST\*\* | Annotations\*\*\* | Container | Maintainer |
 | :--------- | :--------- | :------ | :--- | :--- | :----- | :------------- | :-------- | :--------- |
 | [Bash](https://github.com/bblfsh/bash-driver) | bash | beta | 2.13.4 | ✓ | ✓ | ✓ | [✓](https://hub.docker.com/r/bblfsh/bash-driver/) | [juanjux](https://github.com/juanjux) |
-| [C++](https://github.com/bblfsh/cpp-driver) | cpp | beta | 2.13.0 | ✓ | ✓ | ✓ | [✓](https://hub.docker.com/r/bblfsh/cpp-driver/) | [juanjux](https://github.com/juanjux) |
-| [C#](https://github.com/bblfsh/csharp-driver) | csharp | beta | 2.13.3 | ✓ | ✓ | ✓ | [✓](https://hub.docker.com/r/bblfsh/csharp-driver/) | [dennwc](https://github.com/dennwc) |
+| [C++](https://github.com/bblfsh/cpp-driver) | cpp | beta | 2.14.2 | ✓ | ✓ | ✓ | [✓](https://hub.docker.com/r/bblfsh/cpp-driver/) | [juanjux](https://github.com/juanjux) |
+| [C#](https://github.com/bblfsh/csharp-driver) | csharp | beta | 2.14.1 | ✓ | ✓ | ✓ | [✓](https://hub.docker.com/r/bblfsh/csharp-driver/) | [dennwc](https://github.com/dennwc) |
 | [Go](https://github.com/bblfsh/go-driver) | go | beta | 2.9.0 | ✓ | ✓ | ✓ | [✓](https://hub.docker.com/r/bblfsh/go-driver/) | [dennwc](https://github.com/dennwc) |
-| [Java](https://github.com/bblfsh/java-driver) | java | beta | 2.13.0 | ✓ | ✓ | ✓ | [✓](https://hub.docker.com/r/bblfsh/java-driver/) | [dennwc](https://github.com/dennwc) |
-| [JavaScript](https://github.com/bblfsh/javascript-driver) | javascript | beta | 2.13.2 | ✓ | ✓ | ✓ | [✓](https://hub.docker.com/r/bblfsh/javascript-driver/) | [dennwc](https://github.com/dennwc) |
+| [Java](https://github.com/bblfsh/java-driver) | java | beta | 2.14.2 | ✓ | ✓ | ✓ | [✓](https://hub.docker.com/r/bblfsh/java-driver/) | [dennwc](https://github.com/dennwc) |
+| [JavaScript](https://github.com/bblfsh/javascript-driver) | javascript | beta | 2.14.2 | ✓ | ✓ | ✓ | [✓](https://hub.docker.com/r/bblfsh/javascript-driver/) | [dennwc](https://github.com/dennwc) |
 | [PHP](https://github.com/bblfsh/php-driver) | php | beta | 2.13.4 | ✓ | ✓ | ✓ | [✓](https://hub.docker.com/r/bblfsh/php-driver/) | [juanjux](https://github.com/juanjux) |
-| [Python](https://github.com/bblfsh/python-driver) | python | beta | 2.13.4 | ✓ | ✓ | ✓ | [✓](https://hub.docker.com/r/bblfsh/python-driver/) | [juanjux](https://github.com/juanjux) |
-| [Ruby](https://github.com/bblfsh/ruby-driver) | ruby | beta | 2.13.4 | ✓ | ✓ | ✓ | [✓](https://hub.docker.com/r/bblfsh/ruby-driver/) | [juanjux](https://github.com/juanjux) |
+| [Python](https://github.com/bblfsh/python-driver) | python | beta | 2.14.0 | ✓ | ✓ | ✓ | [✓](https://hub.docker.com/r/bblfsh/python-driver/) | [juanjux](https://github.com/juanjux) |
+| [Ruby](https://github.com/bblfsh/ruby-driver) | ruby | beta | 2.14.1 | ✓ | ✓ | ✓ | [✓](https://hub.docker.com/r/bblfsh/ruby-driver/) | [juanjux](https://github.com/juanjux) |
 | [TypeScript](https://github.com/bblfsh/typescript-driver) | typescript | alpha | 2.9.0 | ✓ | ✗ | ✗ | [✓](https://hub.docker.com/r/bblfsh/typescript-driver/) | [dennwc](https://github.com/dennwc) |
 
 ## In development


### PR DESCRIPTION
Just a result of `make languages`, so check which drivers were already migrated to SDK 2.14.x