### PR TITLE
Clarify current status of the clients, v2 and coverage breadth

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,27 +29,26 @@ Some of the use cases that we aim to support with UAST are:
 
 #### Universal AST coverage
 
-Not all the constructs are converted in a language-independent way yet.
-As of 1Q2019, every language driver is expected to only support Identifiers,
-String (literals), Imports, Functions in the [Universal AST schema](uast/uast-specification-v2.md).
+Not all constructs are converted in a language-independent way yet.
+As of Q1 2019, every language driver is expected to support Identifiers,
+String literals, Imports, and Functions in the [Universal AST schema](uast/uast-specification-v2.md).
 
-That is almost everything that let's one to examine the symbols exported
-by the package, but not the control flow (yet).
+That is sufficient to examine the symbols exported by the package, but not control flow (yet).
 
-Meanwhile, in order to locate constracts that are not covered by UAST
+Meanwhile, in order to identify constructs that are not covered by the UAST
 schema yet - one can look for a `@role` field.
 A [Role](https://godoc.org/gopkg.in/bblfsh/sdk.v2/uast/role#Role) is added
 to every native AST node and it contains a language-independent annotations.
-Underlying tree structure for a constract will be different between languages though.
+However, the tree structure for a role construct may be different between languages.
 
 #### Protocol v2
-Currently, Babelfish is in the process of transition to [v2 protocol](uast/uast-specification-v2.md),
-new node representation and Semantic UAST.
 
-All the beta+ drivers support it in the latest version
-and requires bblfshd >= 2.6.1.
+Currently, Babelfish is in the process of transition to an updated data model, denoted [UAST v2](uast/uast-specification-v2.md),
+which includes a new node representation and canonicalized ("semantic") UAST structures.
 
-Libuast was updated to support the new node format, but some of the
+All the beta+ drivers support UAST v2 in their latest versions. UAST v2 support requires bblfshd ≥ 2.6.1.
+
+Libuast has been updated to support the new node format, but some of the
 the [clients](./using-babelfish/clients.md) may still work in v1 compatibility mode
 to be able to execute XPath queries.
 

--- a/README.md
+++ b/README.md
@@ -27,17 +27,33 @@ Some of the use cases that we aim to support with UAST are:
 
 ### Current status
 
-Currently, Babelfish is in the process of transition to v2 protocol, new
-node representation and Semantic UAST.
+#### Universal AST coverage
 
-All the beta+ drivers support these new features in the latest version
+Not all the constructs are converted in a language-independent way yet.
+As of 1Q2019, every language driver is expected to only support Identifiers,
+String (literals), Imports, Functions in the [Universal AST schema](uast/uast-specification-v2.md).
+
+That is almost everything that let's one to examine the symbols exported
+by the package, but not the control flow (yet).
+
+Meanwhile, in order to locate constracts that are not covered by UAST
+schema yet - one can look for a `@role` field.
+A [Role](https://godoc.org/gopkg.in/bblfsh/sdk.v2/uast/role#Role) is added
+to every native AST node and it contains a language-independent annotations.
+Underlying tree structure for a constract will be different between languages though.
+
+#### Protocol v2
+Currently, Babelfish is in the process of transition to [v2 protocol](uast/uast-specification-v2.md),
+new node representation and Semantic UAST.
+
+All the beta+ drivers support it in the latest version
 and requires bblfshd >= 2.6.1.
 
-Libuast was not yet updated to support the new node format, thus all
-the [clients](./using-babelfish/clients.md) still work in v1 compatibility mode
+Libuast was updated to support the new node format, but some of the
+the [clients](./using-babelfish/clients.md) may still work in v1 compatibility mode
 to be able to execute XPath queries.
 
-See [v2 transition options](./using-babelfish/advanced-usage.md) for details.
+See [v2 transition options](./using-babelfish/advanced-usage.md#protocol-v2-transition) for details.
 
 ### Further Reading
 

--- a/using-babelfish/advanced-usage.md
+++ b/using-babelfish/advanced-usage.md
@@ -12,7 +12,7 @@ During the transition to Babelfish v2 protocol and Semantic UAST client may choo
    Thus, to query `uast:Identifier` the client should omit the namespace: `//Identifier`.
 
 3) Try the new UASTv2 representation by using Go client and the `ParseRequestV2`.
-   This is not yet supported by all the clients, so check [client's current status](](./using-babelfish/clients.md)) first.
+   This is not yet supported by all the clients, so check [client's current status](clients.md) first.
 
 ## Adding all drivers
 

--- a/using-babelfish/advanced-usage.md
+++ b/using-babelfish/advanced-usage.md
@@ -12,8 +12,7 @@ During the transition to Babelfish v2 protocol and Semantic UAST client may choo
    Thus, to query `uast:Identifier` the client should omit the namespace: `//Identifier`.
 
 3) Try the new UASTv2 representation by using Go client and the `ParseRequestV2`.
-   There is no XPath query support at the moment, so this option should only
-   be considered if you want to access the new UAST directly.
+   This is not yet supported by all the clients, so check [client's current status](](./using-babelfish/clients.md)) first.
 
 ## Adding all drivers
 


### PR DESCRIPTION
A quick update based on recent discussion from [#babelfish community slack](https://sourced-community.slack.com/archives/C5JAKNM99/p1553258159016000), to clarify current status of
 - clients
 - protocol v2
 - U coverage from UAST