### PR TITLE
HOTFIX: better GitBook generated HTML in types.html

### DIFF
--- a/_tools/types/main.go
+++ b/_tools/types/main.go
@@ -330,7 +330,7 @@ in every driver the following two values are reported:
  - _fixtures usage_  - number of times this type was used in driver _fixtures_ (_*.sem.uast_ files)
  - _code usage_ - number of times this type was usind in the driver mapping DSL code (_normalizer.go_ file)
 
-The format is <_fixtures usage_>/<_code usage_> in case _code usage_ is not zero.
+The format is _<fixtures usage>_/_<code usage>_ in case _code usage_ is not zero.
 Otherwise, only _fixture usage_ is report.
 
 `

--- a/uast/types.md
+++ b/uast/types.md
@@ -6,7 +6,7 @@ in every driver the following two values are reported:
  - _fixtures usage_  - number of times this type was used in driver _fixtures_ (_*.sem.uast_ files)
  - _code usage_ - number of times this type was usind in the driver mapping DSL code (_normalizer.go_ file)
 
-The format is <_fixtures usage_>/<_code usage_> in case _code usage_ is not zero.
+The format is _<fixtures usage>_/_<code usage>_ in case _code usage_ is not zero.
 Otherwise, only _fixture usage_ is report.
 
 |                         |[bash](https://github.com/bblfsh/bash-driver)|[cpp](https://github.com/bblfsh/cpp-driver)|[csharp](https://github.com/bblfsh/csharp-driver)|[go](https://github.com/bblfsh/go-driver)|[java](https://github.com/bblfsh/java-driver)|[javascript](https://github.com/bblfsh/javascript-driver)|[php](https://github.com/bblfsh/php-driver)|[python](https://github.com/bblfsh/python-driver)|[ruby](https://github.com/bblfsh/ruby-driver)|[typescript](https://github.com/bblfsh/typescript-driver)|


### PR DESCRIPTION
Fixing ` <_fixtures usage_="">/<_code usage_="">`  from  https://doc.bblf.sh/uast/types.html