### PR TITLE
Fixes for UAST types table

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 _book/
+_drivers/

--- a/_tools/types/main.go
+++ b/_tools/types/main.go
@@ -303,8 +303,10 @@ func formatMarkdownTable(drivers []*driverStats, uastTypes []uastType) {
 					dr.uastInFixturesCount[typee.name],
 					dr.uastInCodeCount[typee.name],
 				)
+			} else if v := dr.uastInFixturesCount[typee.name]; v > 0 {
+				fmt.Printf(" %d |", v)
 			} else {
-				fmt.Printf(" %d |", dr.uastInFixturesCount[typee.name])
+				fmt.Printf(" - |")
 			}
 		}
 		fmt.Println()

--- a/_tools/types/main.go
+++ b/_tools/types/main.go
@@ -332,7 +332,7 @@ in every driver the following two values are reported:
  - _fixtures usage_  - number of times this type was used in driver _fixtures_ (_*.sem.uast_ files)
  - _code usage_ - number of times this type was usind in the driver mapping DSL code (_normalizer.go_ file)
 
-The format is _<fixtures usage>_/_<code usage>_ in case _code usage_ is not zero.
+The format is _fixtures usage_ / _code usage_ in case _code usage_ is not zero.
 Otherwise, only _fixture usage_ is report.
 
 `

--- a/_tools/types/main.go
+++ b/_tools/types/main.go
@@ -31,7 +31,7 @@ const (
 )
 
 var (
-	reposRootPath = filepath.Join(".", "drivers")
+	reposRootPath = filepath.Join(".", "_drivers")
 	uastNodeRe    = regexp.MustCompile("uast:[^\"]*")
 
 	pprof      = flag.Bool("pprof", false, "Start a pprof profiler HTTP service at "+pprofAddr)

--- a/_tools/types/main.go
+++ b/_tools/types/main.go
@@ -80,8 +80,9 @@ func run() error {
 }
 
 type driverStats struct {
-	url                 string
-	language            string
+	url                 string         // driver repository URL
+	name                string         // human-readable language name
+	language            string         // language identifier
 	path                string         // path in local FS to the driver source code clone
 	skip                bool           // skip including the driver to the final report
 	fixtureCount        int            // number of fixture files for a driver
@@ -107,6 +108,7 @@ func listDrivers() ([]*driverStats, error) {
 			continue
 		}
 		drivers = append(drivers, &driverStats{
+			name:                l.Name,
 			language:            l.Language,
 			url:                 l.RepositoryURL(),
 			path:                l.RepositoryURL()[strings.LastIndex(l.RepositoryURL(), "/"):],
@@ -291,7 +293,7 @@ func formatMarkdownTable(drivers []*driverStats, uastTypes []uastType) {
 	formatMarkdownTableHeader(drs)
 	for _, typee := range uastTypes {
 		// %25s produces nice ASCII result
-		fmt.Printf("|[%s](%s)|",
+		fmt.Printf("| [%s](%s) |",
 			strings.Replace(typee.name, ".", ":", 1),
 			goDocURL+typee.name[strings.IndexRune(typee.name, '.')+1:],
 		)
@@ -313,7 +315,7 @@ func formatMarkdownTableHeader(drivers []*driverStats) {
 	fmt.Printf("|%25s|", "")
 	for _, dr := range drivers {
 		// %5s produces nice ASCII result
-		fmt.Printf("[%s](%s)|", dr.language, dr.url)
+		fmt.Printf(" [%s](%s) |", dr.name, dr.url)
 	}
 	fmt.Print("\n| :---------------------- |")
 	for range drivers {

--- a/uast/types.md
+++ b/uast/types.md
@@ -6,28 +6,28 @@ in every driver the following two values are reported:
  - _fixtures usage_  - number of times this type was used in driver _fixtures_ (_*.sem.uast_ files)
  - _code usage_ - number of times this type was usind in the driver mapping DSL code (_normalizer.go_ file)
 
-The format is _<fixtures usage>_/_<code usage>_ in case _code usage_ is not zero.
+The format is _fixtures usage_ / _code usage_ in case _code usage_ is not zero.
 Otherwise, only _fixture usage_ is report.
 
-|                         |[bash](https://github.com/bblfsh/bash-driver)|[cpp](https://github.com/bblfsh/cpp-driver)|[csharp](https://github.com/bblfsh/csharp-driver)|[go](https://github.com/bblfsh/go-driver)|[java](https://github.com/bblfsh/java-driver)|[javascript](https://github.com/bblfsh/javascript-driver)|[php](https://github.com/bblfsh/php-driver)|[python](https://github.com/bblfsh/python-driver)|[ruby](https://github.com/bblfsh/ruby-driver)|[typescript](https://github.com/bblfsh/typescript-driver)|
+|                         | [Bash](https://github.com/bblfsh/bash-driver) | [C++](https://github.com/bblfsh/cpp-driver) | [C#](https://github.com/bblfsh/csharp-driver) | [Go](https://github.com/bblfsh/go-driver) | [Java](https://github.com/bblfsh/java-driver) | [JavaScript](https://github.com/bblfsh/javascript-driver) | [PHP](https://github.com/bblfsh/php-driver) | [Python](https://github.com/bblfsh/python-driver) | [Ruby](https://github.com/bblfsh/ruby-driver) | [TypeScript](https://github.com/bblfsh/typescript-driver) |
 | :---------------------- | :-- | :-- | :-- | :-- | :-- | :-- | :-- | :-- | :-- | :-- |
-|[uast:Position](https://godoc.org/github.com/bblfsh/sdk/uast#Position)| 15884 | 52948 | 36468 | 45464 | 12684 | 69088 | 9738 | 16924 | 7992 | 2348 |
-|[uast:Positions](https://godoc.org/github.com/bblfsh/sdk/uast#Positions)| 7942 | 26474 | 18258 | 18530 | 6342 | 34580 | 6557 | 11319 | 3996 | 1174 |
-|[uast:Identifier](https://godoc.org/github.com/bblfsh/sdk/uast#Identifier)| 1840 | 9805 | 3028 | 8129 | 2043 | 11817 | 2097 | 4758 | 1683 | 0 |
-|[uast:String](https://godoc.org/github.com/bblfsh/sdk/uast#String)| 538 | 729 | 118 | 150 | 21 | 670 | 299 | 429 | 267 | 0 |
-|[uast:Bool](https://godoc.org/github.com/bblfsh/sdk/uast#Bool)| 0 | 0 | 29 | 0 | 0 | 0 | 0 | 34 | 55 | 0 |
-|[uast:QualifiedIdentifier](https://godoc.org/github.com/bblfsh/sdk/uast#QualifiedIdentifier)| 0 | 948 | 24 | 72 | 36 | 0 | 30 | 18 | 0 | 0 |
-|[uast:Comment](https://godoc.org/github.com/bblfsh/sdk/uast#Comment)| 121 | 178 | 40 | 870 | 60 | 1986 | 146 | 331 | 6 | 0 |
-|[uast:Group](https://godoc.org/github.com/bblfsh/sdk/uast#Group)| 0 | 0 | 24 | 0 | 12 | 0 | 0 | 3 | 0 | 0 |
-|[uast:FunctionGroup](https://godoc.org/github.com/bblfsh/sdk/uast#FunctionGroup)| 28 | 274 | 222 | 236 | 120 | 36 | 54 | 202 | 114 | 0 |
-|[uast:Block](https://godoc.org/github.com/bblfsh/sdk/uast#Block)| 28 | 600 | 322 | 765 | 369 | 1352 | 411 | 202 | 326 | 0 |
-|[uast:Alias](https://godoc.org/github.com/bblfsh/sdk/uast#Alias)| 28 | 274 | 223 | 242 | 120 | 74 | 84 | 217 | 114 | 0 |
-|[uast:Import](https://godoc.org/github.com/bblfsh/sdk/uast#Import)| 0 | 0 | 38 | 198 | 13 | 35 | 0 | 0 | 0 | 0 |
-|[uast:RuntimeImport](https://godoc.org/github.com/bblfsh/sdk/uast#RuntimeImport)| 0 | 0 | 0 | 0 | 0 | 0 | 29 | 66 | 12 | 0 |
-|[uast:RuntimeReImport](https://godoc.org/github.com/bblfsh/sdk/uast#RuntimeReImport)| 0 | 0 | 0 | 0 | 0 | 0 | 7 | 0 | 0 | 0 |
-|[uast:InlineImport](https://godoc.org/github.com/bblfsh/sdk/uast#InlineImport)| 0 | 144 | 0 | 0 | 0 | 0 | 0 | 0 | 0 | 0 |
-|[uast:Argument](https://godoc.org/github.com/bblfsh/sdk/uast#Argument)| 0 | 386 | 405 | 645 | 94 | 71 | 234 | 478 | 166 | 0 |
-|[uast:FunctionType](https://godoc.org/github.com/bblfsh/sdk/uast#FunctionType)| 28 | 274 | 222 | 259 | 120 | 36 | 54 | 202 | 114 | 0 |
-|[uast:Function](https://godoc.org/github.com/bblfsh/sdk/uast#Function)| 28 | 274 | 222 | 236 | 120 | 36 | 54 | 202 | 114 | 0 |
+| [uast:Position](https://godoc.org/github.com/bblfsh/sdk/uast#Position) | 15884 | 52948 | 36468 | 45464 | 12684 | 69088 | 9738 | 16924 | 7992 | 2348 |
+| [uast:Positions](https://godoc.org/github.com/bblfsh/sdk/uast#Positions) | 7942 | 26474 | 18258 | 18530 | 6342 | 34580 | 6557 | 11319 | 3996 | 1174 |
+| [uast:Identifier](https://godoc.org/github.com/bblfsh/sdk/uast#Identifier) | 1840 | 9805 | 3028 | 8129 | 2043 | 11817 | 2097 | 4758 | 1683 | - |
+| [uast:String](https://godoc.org/github.com/bblfsh/sdk/uast#String) | 538 | 729 | 118 | 150 | 21 | 670 | 299 | 429 | 267 | - |
+| [uast:Bool](https://godoc.org/github.com/bblfsh/sdk/uast#Bool) | - | - | 29 | - | - | - | - | 34 | 55 | - |
+| [uast:QualifiedIdentifier](https://godoc.org/github.com/bblfsh/sdk/uast#QualifiedIdentifier) | - | 948 | 24 | 72 | 36 | - | 30 | 18 | - | - |
+| [uast:Comment](https://godoc.org/github.com/bblfsh/sdk/uast#Comment) | 121 | 178 | 40 | 870 | 60 | 1986 | 146 | 331 | 6 | - |
+| [uast:Group](https://godoc.org/github.com/bblfsh/sdk/uast#Group) | - | - | 24 | - | 12 | - | - | 3 | - | - |
+| [uast:FunctionGroup](https://godoc.org/github.com/bblfsh/sdk/uast#FunctionGroup) | 28 | 274 | 222 | 236 | 120 | 36 | 54 | 202 | 114 | - |
+| [uast:Block](https://godoc.org/github.com/bblfsh/sdk/uast#Block) | 28 | 600 | 322 | 765 | 369 | 1352 | 411 | 202 | 326 | - |
+| [uast:Alias](https://godoc.org/github.com/bblfsh/sdk/uast#Alias) | 28 | 274 | 223 | 242 | 120 | 74 | 84 | 217 | 114 | - |
+| [uast:Import](https://godoc.org/github.com/bblfsh/sdk/uast#Import) | - | - | 38 | 198 | 13 | 35 | - | - | - | - |
+| [uast:RuntimeImport](https://godoc.org/github.com/bblfsh/sdk/uast#RuntimeImport) | - | - | - | - | - | - | 29 | 66 | 12 | - |
+| [uast:RuntimeReImport](https://godoc.org/github.com/bblfsh/sdk/uast#RuntimeReImport) | - | - | - | - | - | - | 7 | - | - | - |
+| [uast:InlineImport](https://godoc.org/github.com/bblfsh/sdk/uast#InlineImport) | - | 144 | - | - | - | - | - | - | - | - |
+| [uast:Argument](https://godoc.org/github.com/bblfsh/sdk/uast#Argument) | - | 386 | 405 | 645 | 94 | 71 | 234 | 478 | 166 | - |
+| [uast:FunctionType](https://godoc.org/github.com/bblfsh/sdk/uast#FunctionType) | 28 | 274 | 222 | 259 | 120 | 36 | 54 | 202 | 114 | - |
+| [uast:Function](https://godoc.org/github.com/bblfsh/sdk/uast#Function) | 28 | 274 | 222 | 236 | 120 | 36 | 54 | 202 | 114 | - |
 
 **Don't see your favorite AST construct represented? [Help us!](../join-the-community.md)**


### PR DESCRIPTION
Some fixes to UAST types table:
* Use `_drivers` dir by default and add it to `.gitignore`.
* Use language name instead of ID in the header.
* Print `-` instead of zero.
* Fix formatting in the header.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bblfsh/documentation/258)
<!-- Reviewable:end -->
