### PR TITLE
Docs readability improvements

### DIFF
--- a/uast/types.md
+++ b/uast/types.md
@@ -4,10 +4,10 @@
 For every [UAST type](semantic-uast.md#types)
 in every driver the following two values are reported:
  - _fixtures usage_  - number of times this type was used in driver _fixtures_ (_*.sem.uast_ files)
- - _code usage_ - number of times this type was usind in the driver mapping DSL code (_normalizer.go_ file)
+ - _code usage_ - number of times this type was used in in the driver mapping DSL code (_normalizer.go_ file)
 
 The format is _fixtures usage_ / _code usage_ in case _code usage_ is not zero.
-Otherwise, only _fixture usage_ is report.
+Otherwise, only _fixture usage_ is reported.
 
 |                         | [Bash](https://github.com/bblfsh/bash-driver) | [C++](https://github.com/bblfsh/cpp-driver) | [C#](https://github.com/bblfsh/csharp-driver) | [Go](https://github.com/bblfsh/go-driver) | [Java](https://github.com/bblfsh/java-driver) | [JavaScript](https://github.com/bblfsh/javascript-driver) | [PHP](https://github.com/bblfsh/php-driver) | [Python](https://github.com/bblfsh/python-driver) | [Ruby](https://github.com/bblfsh/ruby-driver) | [TypeScript](https://github.com/bblfsh/typescript-driver) |
 | :---------------------- | :-- | :-- | :-- | :-- | :-- | :-- | :-- | :-- | :-- | :-- |

--- a/uast/uast-specification-v2.md
+++ b/uast/uast-specification-v2.md
@@ -6,7 +6,7 @@ A Universal Abstract Syntax Tree \(UAST\) is a normalized form of [Abstract Synt
 By definition, the UAST representation does not depend on the language
 of the parser for source files.
 
-UAST is defined by two separate specifications:
+UAST is defined by three separate specifications:
 
 * [Node representation](./representation-v2.md) - defines a common transport
   format for the UAST.

--- a/using-babelfish/babelfish-protocol.md
+++ b/using-babelfish/babelfish-protocol.md
@@ -13,7 +13,7 @@ You can read [the server](https://github.com/bblfsh/sdk/blob/94e3b212553e761677d
 
 ### ParseRequest
 
-Issued by the client to request that a source code file must be parsed to an UAST tree. The client must provide the code in the `content` field, the programming language in the `language` field \(which must be one of the [languages currently supported](../languages.md)\) or empty to enable auto-detection\) and the `filename` field with the name of the file containing the source code.
+Issued by the client to request that a source code file must be parsed to an UAST tree. The client must provide the code in the `content` field, the programming language in the `language` field \(which must be one of the [languages currently supported](../languages.md) or empty to enable auto-detection\) and the `filename` field with the name of the file containing the source code.
 
 Example:
 
@@ -56,4 +56,3 @@ The status contains the return code of the Request. If it's != 0 \(which will be
     "roles": ["role1", "role2", ...]
 }
 ```
-

--- a/using-babelfish/clients.md
+++ b/using-babelfish/clients.md
@@ -153,7 +153,7 @@ When using one of the clients that support libuast you can query the UAST result
 
 ## Iterators
 
-The client also allow you to instance an Iterator object and iterate over the tree on several predefined orders:
+The client also allows you to instance an Iterator object and iterate over the tree on several predefined orders:
 
 * [Pre-Order](https://en.wikipedia.org/wiki/Tree_traversal#Pre-order)
 * [Post-Order](https://en.wikipedia.org/wiki/Tree_traversal#Post-order)

--- a/using-babelfish/grpc-usage-example.md
+++ b/using-babelfish/grpc-usage-example.md
@@ -59,7 +59,7 @@ Now that we've created a request, we need to send it \(previous code omitted\):
 
 The code in the previous section returned a `ParseResponse` object that will have the format of the [ParseResponse](babelfish-protocol.md#ParseResponse) as seen on the [server protocol](babelfish-protocol.md) page. You should check the `status` \(`Status` in the case of Go, since public members start with uppercase\); only a value of `protocol.Status.OK` will indicate success.
 
-The most important member of the `ParseResponse` object is undoubtly `uast` \(`UAST` in Go\). This will contain a `Node` object which the [structure detailed in the previous page](babelfish-protocol.md#Nodes). This first node returned would be the root node of the UAST, and you typically would iterate over the node children \(contained in the aptly named `children` field\) typically using [a visitor](https://en.wikipedia.org/wiki/Visitor_pattern) and reading the `token`s and `roles` in the tree to do your tool.
+The most important member of the `ParseResponse` object is undoubtedly `uast` \(`UAST` in Go\). This will contain a `Node` object with the [structure detailed in the previous page](babelfish-protocol.md#Nodes). This first node returned would be the root node of the UAST, and you typically would iterate over the children node \(contained in the aptly named `children` field\) typically using [a visitor](https://en.wikipedia.org/wiki/Visitor_pattern) and reading the `token`s and `role`s in the tree to do your tool.
 
 For demonstration purposes, we'll just write a simple function that iterates the tree in preorder and print the node tokens:
 
@@ -132,4 +132,3 @@ func printTokens(n *uast.Node) {
     }
 }
 ```
-

--- a/using-babelfish/grpc-usage-example.md
+++ b/using-babelfish/grpc-usage-example.md
@@ -59,7 +59,7 @@ Now that we've created a request, we need to send it \(previous code omitted\):
 
 The code in the previous section returned a `ParseResponse` object that will have the format of the [ParseResponse](babelfish-protocol.md#ParseResponse) as seen on the [server protocol](babelfish-protocol.md) page. You should check the `status` \(`Status` in the case of Go, since public members start with uppercase\); only a value of `protocol.Status.OK` will indicate success.
 
-The most important member of the `ParseResponse` object is undoubtedly `uast` \(`UAST` in Go\). This will contain a `Node` object with the [structure detailed in the previous page](babelfish-protocol.md#Nodes). This first node returned would be the root node of the UAST, and you typically would iterate over the children node \(contained in the aptly named `children` field\) typically using [a visitor](https://en.wikipedia.org/wiki/Visitor_pattern) and reading the `token`s and `role`s in the tree to do your tool.
+The most important member of the `ParseResponse` object is undoubtedly `uast` \(`UAST` in Go\). This will contain a `Node` object with the [structure detailed in the previous page](babelfish-protocol.md#Nodes). This first node returned would be the root node of the UAST, and you typically would iterate over the children nodes \(contained in the aptly named `children` field\) typically using [a visitor](https://en.wikipedia.org/wiki/Visitor_pattern) and reading the `token`s and `role`s in the tree to do your tool.
 
 For demonstration purposes, we'll just write a simple function that iterates the tree in preorder and print the node tokens:
 


### PR DESCRIPTION
Some typos and grammar corrections. This includes changes for the [gRPC usage example](https://doc.bblf.sh/using-babelfish/grpc-usage-example.html) which is outdated #227 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bblfsh/documentation/265)
<!-- Reviewable:end -->
