### PR TITLE
Fix the Gitbook build in CI and locally.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,21 +1,16 @@
+.PHONY: gitbook
 
+gitbook:
+	npm install -g gitbook-cli
 
-GITBOOK_CMD := $(shell command -v gitbook 2> /dev/null)
-GITBOOK_BUILD := $(GITBOOK_CMD) build
-GITBOOK_SERVE := $(GITBOOK_CMD) serve
-GITBOOK_INSTALL := $(GITBOOK_CMD) install
-
-node_modules:
-ifndef GITBOOK_CMD
-	$(error "Please, install gitbook-cli: https://toolchain.gitbook.com/setup.html")
-endif
-	$(GITBOOK_INSTALL)
+node_modules: gitbook
+	gitbook install
 
 build: node_modules
-	$(GITBOOK_BUILD)
+	gitbook build
 
 serve: node_modules
-	$(GITBOOK_SERVE)
+	gitbook serve
 
 roles:
 	go run _tools/roles/main.go > uast/roles.md


### PR DESCRIPTION
The default installation is missing some plugins that we depend on.
Restructure and simplify the make rules to ensure we install the tool and the
plugins unconditionally. We can trust npm to use its caches sensibly.

Fixes #271.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bblfsh/documentation/273)
<!-- Reviewable:end -->
